### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2024-09-17
+
+Initial release.
+
+### Added
+
+- Add README
+- Introduce a config file
+- Add command line arguments
+- Make `ChatClientConfig` public
+- Support setting API key in a config
+- Report recoverable errors
+- Initial commit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "unspoken"
+description = "OpenAI chat API client library and CLI interface."
+license = "MIT"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
## [0.1.0] - 2024-09-17

Initial release.

### Added

- Add README
- Introduce a config file
- Add command line arguments
- Make `ChatClientConfig` public
- Support setting API key in a config
- Report recoverable errors
- Initial commit